### PR TITLE
Set width and height to 1 for hidden input

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -14,8 +14,8 @@ const styles = StyleSheet.create({
     width: getScreenWidth(),
   },
   hiddenTextInput: {
-    width: 0,
-    height: 0,
+    width: 1,
+    height: 1,
     backgroundColor: 'transparent',
   },
 });


### PR DESCRIPTION
The input is broken on Android devices. You can not type into an input which has no layout. This change set the input width and height to `1`.

Working example on Android emulator:

![sms_verifyinput](https://user-images.githubusercontent.com/57303/69355138-964a7d00-0c81-11ea-928f-c334fd92f166.gif)
